### PR TITLE
Add "All Files" filter option to open dialog

### DIFF
--- a/app/services/electron.js
+++ b/app/services/electron.js
@@ -61,7 +61,7 @@ function electronservice(common) {
     }
 
     function open(onOpen, onNoOpen) {
-        dialog.showOpenDialog(remote.getCurrentWindow(), { filters: [{ name: 'Threat Models', extensions: ['json'] }] }, function (fileNames) {
+        dialog.showOpenDialog(remote.getCurrentWindow(), { filters: [{ name: 'Threat Models', extensions: ['json'] }, { name: 'All Files', extensions: ['*'] }] }, function (fileNames) {
             if (!_.isUndefined(fileNames)) {
                 onOpen(fileNames);
             } else {


### PR DESCRIPTION
This is a workaround for #115 so that files saved without an extension can still be opened.
It is also a norm for open dialogs to have this option.