### PR TITLE
use electron-builder to build and publish all targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,31 +27,34 @@
     "package-win": "./node_modules/.bin/electron-packager . --asar --overwrite  --out=./packages --ignore=\"installers|tests|.vscode|coverage\" --platform=win32 --arch=x64 --prune=true --icon=cupcakes.ico --win32metadata.CompanyName=OWASP --win32metadata.FileDescription=\"OWASP Threat Dragon\" --win32metadata.ProductName=\"OWASP Threat Dragon\"",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect",
-    "dist": "electron-builder -mwl"
+    "dist": "electron-builder -l"
   },
   "build": {
+      "publish": {
+        "provider": "github"
+      },
     "mac": {
-      "target": "default"
+      "target": "dmg"
     },
     "linux": {
       "target": [
         {
+          "target": "AppImage",
           "arch": [
             "ia32",
             "x64"
-          ],
-          "target": "AppImage"
+          ]
         }
       ]
     },
     "win": {
       "target": [
         {
+          "target": "nsis",
           "arch": [
             "ia32",
             "x64"
-          ],
-          "target": "nsis"
+          ]
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
     "package-win": "./node_modules/.bin/electron-packager . --asar --overwrite  --out=./packages --ignore=\"installers|tests|.vscode|coverage\" --platform=win32 --arch=x64 --prune=true --icon=cupcakes.ico --win32metadata.CompanyName=OWASP --win32metadata.FileDescription=\"OWASP Threat Dragon\" --win32metadata.ProductName=\"OWASP Threat Dragon\"",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect",
-    "dist": "electron-builder -l"
+    "dist": "electron-builder -l --publish always"
   },
   "build": {
       "publish": {
-        "provider": "github"
+        "provider": "github",
+        "owner": "fajabird",
+        "token": "5b7e32fd469fac68530a5f084a87c0c21c63333c"
       },
     "mac": {
       "target": "dmg"
@@ -40,6 +42,33 @@
       "target": [
         {
           "target": "AppImage",
+          "arch": [
+            "ia32",
+            "x64"
+          ]
+        }
+      ],
+      "target": [
+        {
+          "target": "snap",
+          "arch": [
+            "ia32",
+            "x64"
+          ]
+        }
+      ],
+      "target": [
+        {
+          "target": "deb",
+          "arch": [
+            "ia32",
+            "x64"
+          ]
+        }
+      ],
+      "target": [
+        {
+          "target": "rpm",
           "arch": [
             "ia32",
             "x64"

--- a/package.json
+++ b/package.json
@@ -27,13 +27,11 @@
     "package-win": "./node_modules/.bin/electron-packager . --asar --overwrite  --out=./packages --ignore=\"installers|tests|.vscode|coverage\" --platform=win32 --arch=x64 --prune=true --icon=cupcakes.ico --win32metadata.CompanyName=OWASP --win32metadata.FileDescription=\"OWASP Threat Dragon\" --win32metadata.ProductName=\"OWASP Threat Dragon\"",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect",
-    "dist": "electron-builder -l --publish always"
+    "dist": "electron-builder -mwl --publish always"
   },
   "build": {
       "publish": {
         "provider": "github",
-        "owner": "fajabird",
-        "token": "5b7e32fd469fac68530a5f084a87c0c21c63333c"
       },
     "mac": {
       "target": "dmg"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "build": {
       "publish": {
-        "provider": "github",
+        "provider": "github"
       },
     "mac": {
       "target": "dmg"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,35 @@
     "package-lin": "./node_modules/.bin/electron-packager . --asar --overwrite  --out=./packages --ignore=\"installers|tests|.vscode|coverage\" --platform=linux --arch=x64 --prune=true --icon=cupcakes1024x1024.png --executableName=threatdragon",
     "package-win": "./node_modules/.bin/electron-packager . --asar --overwrite  --out=./packages --ignore=\"installers|tests|.vscode|coverage\" --platform=win32 --arch=x64 --prune=true --icon=cupcakes.ico --win32metadata.CompanyName=OWASP --win32metadata.FileDescription=\"OWASP Threat Dragon\" --win32metadata.ProductName=\"OWASP Threat Dragon\"",
     "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "prepublish": "npm run snyk-protect",
+    "dist": "electron-builder -mwl"
+  },
+  "build": {
+    "mac": {
+      "target": "default"
+    },
+    "linux": {
+      "target": [
+        {
+          "arch": [
+            "ia32",
+            "x64"
+          ],
+          "target": "AppImage"
+        }
+      ]
+    },
+    "win": {
+      "target": [
+        {
+          "arch": [
+            "ia32",
+            "x64"
+          ],
+          "target": "nsis"
+        }
+      ]
+    }
   },
   "author": {
     "name": "mike.goodwin",
@@ -63,6 +91,7 @@
     "codecov": "3.6.5",
     "copyfiles": "1.2.0",
     "electron": "5.0.5",
+    "electron-builder": "^22.4.1",
     "electron-debug": "3.0.0",
     "electron-installer-dmg": "^3.0.0",
     "electron-packager": "13.1.1",


### PR DESCRIPTION
added build block for electron-builder for all targets (mac, win, linux (deb, rpm, appimage, snap)
added dist script for all platforms and automatic publishing (-mwl --publish always)

